### PR TITLE
Unit Tests for CustomReplicaSet Controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/ishaansehgal99/CustomReplicaSet
 go 1.20
 
 require (
+	github.com/go-logr/logr v1.2.4
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
+	github.com/stretchr/testify v1.8.1
+	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 	sigs.k8s.io/controller-runtime v0.15.0
@@ -15,9 +18,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
@@ -40,6 +43,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.15.1 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
@@ -61,7 +65,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.27.2 // indirect
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -119,18 +119,27 @@ func TestUpdateRevisionLabel(t *testing.T) {
 		Scheme: scheme,
 	}
 
-	// Call the function to test
-	err := reconciler.updateCRRevisionLabel(context.Background(), cr, rev)
-	assert.NoError(t, err)
+	t.Run("should update the CR revision label", func(t *testing.T) {
+		// Call the function to test
+		err := reconciler.updateCRRevisionLabel(context.Background(), cr, rev)
+		assert.NoError(t, err)
 
-	// Check the updated CustomReplicaSet
-	updatedCR := &customreplicasetv1.CustomReplicaSet{}
-	err = cl.Get(context.Background(), client.ObjectKey{Name: cr.Name, Namespace: cr.Namespace}, updatedCR)
-	assert.NoError(t, err)
+		// Check the updated CustomReplicaSet
+		updatedCR := &customreplicasetv1.CustomReplicaSet{}
+		err = cl.Get(context.Background(), client.ObjectKey{Name: cr.Name, Namespace: cr.Namespace}, updatedCR)
+		assert.NoError(t, err)
 
-	// Assert that the labels were updated correctly
-	assert.Equal(t, rev.Name, updatedCR.Labels["latestRevisionName"])
-	assert.Equal(t, strconv.FormatInt(rev.Revision, 10), updatedCR.Labels["latestRevisionNumber"])
+		// Assert that the labels were updated correctly
+		assert.Equal(t, rev.Name, updatedCR.Labels["latestRevisionName"])
+		assert.Equal(t, strconv.FormatInt(rev.Revision, 10), updatedCR.Labels["latestRevisionNumber"])
+	})
+
+	t.Run("should not update the CR revision label", func(t *testing.T) {
+		err := reconciler.updateCRRevisionLabel(context.Background(), cr, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "invalid controller revision to update CR label with", err.Error())
+	})
+
 }
 
 func TestCreateControllerRevision(t *testing.T) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -19,23 +19,19 @@ package controller
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	customreplicasetv1 "github.com/ishaansehgal99/CustomReplicaSet/api/v1"
 	//+kubebuilder:scaffold:imports
@@ -549,194 +544,6 @@ func TestSearchRevisionHistory(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, revision)
 	})
-}
-
-type BadJSON struct {
-	metav1.TypeMeta // Include this to add the GetObjectKind() method
-}
-
-func (b BadJSON) MarshalJSON() ([]byte, error) {
-	return nil, errors.New("this is a marshal error")
-}
-
-func (b *BadJSON) DeepCopyObject() runtime.Object {
-	return &BadJSON{}
-}
-
-func TestHashControllerRevisionData(t *testing.T) {
-	t.Run("should hash the revision data successfully", func(t *testing.T) {
-		// Define ControllerRevision data
-		revisionData := runtime.RawExtension{
-			Raw: []byte(`{"foo":"bar"}`),
-		}
-
-		// Call function to test
-		hash, err := hashControllerRevisionData(revisionData)
-
-		// Define the expected result (I've pre-computed the hash for {"foo":"bar"} here)
-		expectedHash := "7a38bf81f383f69433ad6e900d35b3e2385593f76a7b7ab5d4355b8ba41ee24b"
-
-		assert.NoError(t, err)
-		assert.Equal(t, expectedHash, hash)
-	})
-
-	t.Run("should return an error when marshalling fails", func(t *testing.T) {
-		// Define ControllerRevision data with unmarshallable data
-		revisionData := runtime.RawExtension{
-			Object: &BadJSON{}, // This type will fail to marshal
-		}
-
-		// Call function to test
-		_, err := hashControllerRevisionData(revisionData)
-
-		assert.Error(t, err)
-	})
-}
-
-func TestConvertCRSpecToJson(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = customreplicasetv1.AddToScheme(scheme)
-
-	t.Run("should convert cr spec to json", func(t *testing.T) {
-		// Create test CustomReplicaSetSpec Object
-		spec := customreplicasetv1.CustomReplicaSetSpec{
-			Replicas:             10,
-			Partition:            5,
-			RevisionHistoryLimit: 20,
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					RestartPolicy: "Never",
-					Containers: []corev1.Container{
-						{
-							Name:    "busybox",
-							Image:   "busybox:latest",
-							Command: []string{"sleep", "3600"},
-						},
-					},
-				},
-			},
-		}
-
-		// Convert the spec to JSON
-		jsonSpec, err := convertCRSpecToJson(spec)
-
-		// There should be no error
-		assert.NoError(t, err)
-
-		// Now unmarshal the jsonSpec back to a CustomReplicaSetSpec object
-		var unmarshaledSpec customreplicasetv1.CustomReplicaSetSpec
-		err = json.Unmarshal(jsonSpec, &unmarshaledSpec)
-
-		// There should be no error
-		assert.NoError(t, err)
-
-		// The unmarshaledSpec should be same as original spec
-		assert.Equal(t, spec, unmarshaledSpec)
-	})
-}
-
-func TestFindCustomReplicaSet(t *testing.T) {
-	logger := zap.New(zap.UseDevMode(true))
-	scheme := runtime.NewScheme()
-	_ = customreplicasetv1.AddToScheme(scheme)
-
-	// Create test request
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      "test-crs",
-			Namespace: "default",
-		},
-	}
-
-	t.Run("should find the custom replica set", func(t *testing.T) {
-		// Create test CustomReplicaSet Object
-		customReplicaSet := &customreplicasetv1.CustomReplicaSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-crs",
-				Namespace: "default",
-			},
-			Spec: customreplicasetv1.CustomReplicaSetSpec{},
-		}
-
-		// Mock Client
-		client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(customReplicaSet).Build()
-
-		// Create test reconciler
-		reconciler := &CustomReplicaSetReconciler{
-			Client: client,
-			Scheme: scheme,
-		}
-
-		// Call function to test
-		crs, err := reconciler.findCustomReplicaSet(context.Background(), req, logger)
-
-		assert.NoError(t, err)
-		assert.Equal(t, "test-crs", crs.Name)
-	})
-
-	t.Run("should return an error when the custom replica set does not exist", func(t *testing.T) {
-		// Mock Client
-		client := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-		// Create test reconciler
-		reconciler := &CustomReplicaSetReconciler{
-			Client: client,
-			Scheme: scheme,
-		}
-
-		_, err := reconciler.findCustomReplicaSet(context.Background(), req, logr.Discard())
-		assert.Error(t, err)
-	})
-}
-
-func TestFindChildPods(t *testing.T) {
-	logger := zap.New(zap.UseDevMode(true))
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-
-	// Create test request
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      "test-crs",
-			Namespace: "default",
-		},
-	}
-	t.Run("should find the child pods", func(t *testing.T) {
-		// Create test Pod Objects
-		pod1 := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod1",
-				Namespace: "default",
-			},
-			Spec: corev1.PodSpec{},
-		}
-
-		pod2 := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod2",
-				Namespace: "default",
-			},
-			Spec: corev1.PodSpec{},
-		}
-
-		// Mock Client
-		client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(pod1, pod2).Build()
-
-		// Create test reconciler
-		reconciler := &CustomReplicaSetReconciler{
-			Client: client,
-			Scheme: scheme,
-		}
-
-		// Call function to test
-		pods, err := reconciler.findChildPods(context.Background(), req, logger)
-
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(pods.Items))
-		assert.Equal(t, "test-pod1", pods.Items[0].Name)
-		assert.Equal(t, "test-pod2", pods.Items[1].Name)
-	})
-
 }
 
 var _ = AfterSuite(func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -91,6 +91,7 @@ var _ = BeforeSuite(func() {
 func TestUpdateRevisionLabel(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = customreplicasetv1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
 
 	// Create a test CustomReplicaSet and ControllerRevision
 	cr := &customreplicasetv1.CustomReplicaSet{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -86,6 +86,14 @@ func TestFindCustomReplicaSet(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = customreplicasetv1.AddToScheme(scheme)
 
+	// Create test request
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-crs",
+			Namespace: "default",
+		},
+	}
+
 	t.Run("should find the custom replica set", func(t *testing.T) {
 		// Create test CustomReplicaSet Object
 		customReplicaSet := &customreplicasetv1.CustomReplicaSet{
@@ -105,14 +113,6 @@ func TestFindCustomReplicaSet(t *testing.T) {
 			Scheme: scheme,
 		}
 
-		// Create test request
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: "default",
-				Name:      "test-crs",
-			},
-		}
-
 		// Call function to test
 		crs, err := reconciler.findCustomReplicaSet(context.Background(), req, logger)
 
@@ -128,14 +128,6 @@ func TestFindCustomReplicaSet(t *testing.T) {
 		reconciler := &CustomReplicaSetReconciler{
 			Client: client,
 			Scheme: scheme,
-		}
-
-		// Create test request
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      "test-crs",
-				Namespace: "default",
-			},
 		}
 
 		_, err := reconciler.findCustomReplicaSet(context.Background(), req, logr.Discard())


### PR DESCRIPTION
This PR introduces unit tests for the CustomReplicaSetController. In this initial PR, the primary focus is on testing the ControllerRevision functionality, specifically including the creation, deletion, and updates of ControllerRevisions.

Subsequent PRs will integrate the ControllerRevision code with the pod management system, and will include comprehensive tests to validate pod management functionality. By ensuring each component is tested individually before integration, we aim to identify and resolve any potential issues at an early stage to ensure the robustness of the CustomReplicaSet Controller.

Code Coverage: 31.7%
