### PR TITLE
Updated CRD with PodTemplate that can take metadata

### DIFF
--- a/api/v1/customreplicaset_types.go
+++ b/api/v1/customreplicaset_types.go
@@ -31,10 +31,50 @@ type PodStatusInfo struct {
 	RestartCount int32  `json:"restartCount"`
 }
 
-// type Revision struct {
-// 	CRSpecHash         string                    `json:"crspechash"`
-// 	ControllerRevision *appv1.ControllerRevision `json:"controllerrevision"`
-// }
+type MetadataWithLabels struct {
+	Labels map[string]string `json:"labels"`
+}
+
+type PodTemplateSpecWithMetadata struct {
+	Metadata MetadataWithLabels `json:"metadata"`
+	Spec     corev1.PodSpec     `json:"spec,omitempty"`
+}
+
+// Need to define these methods for deep copying
+func (in *PodTemplateSpecWithMetadata) DeepCopyInto(out *PodTemplateSpecWithMetadata) {
+	*out = *in
+	out.Metadata = *(in.Metadata).DeepCopy()
+	out.Spec = *(in.Spec).DeepCopy()
+}
+
+func (in *PodTemplateSpecWithMetadata) DeepCopy() *PodTemplateSpecWithMetadata {
+	if in == nil {
+		return nil
+	}
+	out := new(PodTemplateSpecWithMetadata)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *MetadataWithLabels) DeepCopyInto(out *MetadataWithLabels) {
+	*out = *in
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+}
+
+func (in *MetadataWithLabels) DeepCopy() *MetadataWithLabels {
+	if in == nil {
+		return nil
+	}
+	out := new(MetadataWithLabels)
+	in.DeepCopyInto(out)
+	return out
+}
 
 // CustomReplicaSetSpec defines the desired state of CustomReplicaSet
 type CustomReplicaSetSpec struct {
@@ -45,7 +85,7 @@ type CustomReplicaSetSpec struct {
 	Replicas int32 `json:"replicas"`
 
 	// Stores Pod Spec used for creating new pods
-	Template corev1.PodTemplateSpec `json:"template"`
+	Template PodTemplateSpecWithMetadata `json:"template"`
 
 	// Keep track of the number of upgraded replicas
 	Partition int32 `json:"partition"`

--- a/customreplicaset.yaml
+++ b/customreplicaset.yaml
@@ -3,29 +3,17 @@ kind: CustomReplicaSet
 metadata: 
   name: customreplicaset-sample
 spec: 
-  replicas: 8
+  replicas: 10
   template:
-    # metadata:
-    #   labels:
-    #     app: my-app
+    metadata:
+      labels:
+        owner: "" # to be filled in during pod creation
+        revision: "" # to be filled in during pod creation
     spec:
       restartPolicy: Never
       containers:
       - name: busybox
         image: busybox:latest
         command: ["sleep", "3600"]
-  partition: 5  # Number of upgraded pods
+  partition: 7  # Number of upgraded pods
   revisionHistoryLimit: 20 # Max revision history stored
-
-  # upgradedTemplate:
-  #   apiVersion: v1
-  #   kind: Pod
-  #   metadata:
-  #     labels:
-  #       app: my-app2
-  #   spec:
-  #     restartPolicy: Never
-  #     containers:
-  #     - name: busybox
-  #       image: busybox:latest
-  #       command: ["sleep", "3600"]


### PR DESCRIPTION
This PR allows a pod to be be able to store metadata, like its owner and revision number. This is useful for keeping track of how many pods are owned by the customreplicaset instance and what versions they are at.  